### PR TITLE
Amend Autorelease workflow and add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+⚠️ Make sure you [release a new version of this gem](https://github.com/alphagov/siteimprove_api_client/tree/main/lib/siteimprove_api_client#L14) after merging your changes. ⚠️
+
+Refer to the [existing docs](https://docs.publishing.service.gov.uk/manual/publishing-a-ruby-gem.html#ruby-version-compatibility) if you are making changes to the supported Ruby versions.

--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '00 13 * * 2'
+    - cron: '30 10 * * 1-5' # 10:30am UTC, Mon-Fri.
 
 jobs:
   autorelease:


### PR DESCRIPTION
Run autorelease workflow daily. Running it on a weekly schedule means there are often commits other than Dependabot ones and a PR to bump version will not be opened.

Adds a PR template to remind people to release new gem versions and point to Ruby version docs.

[Trello card](https://trello.com/c/rLg8qr3S/3533-evaluate-effectiveness-of-gem-auto-release-workflow-and-decide-if-we-want-to-roll-it-out-across-govuk)