### PR TITLE
Configure CI workflow to handle concurrent releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   codeql-sast:
     name: CodeQL SAST scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         ruby: [ 3.1, 3.2, 3.3 ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # CHANGELOG
 
+## 1.0.2
+
+* Configure CI workflow to handle concurrent releases ([#44](https://github.com/alphagov/siteimprove_api_client/pull/44))
+
 ## 1.0.1
 
 * Add Acion Linting Github Checks, Ratchet version to 1.0.1
 
-# 1.0.0
+## 1.0.0
 
 * Initial version

--- a/lib/siteimprove_api_client/version.rb
+++ b/lib/siteimprove_api_client/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 6.6.0
 =end
 
 module SiteimproveAPIClient
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
**As a** platform engineer
**I want** our deployment process for our app repos to handle concurrent releases
**so that** we avoid issues with incorrect ordering of releases

https://github.com/alphagov/govuk-infrastructure/issues/2123