### PR TITLE
Introduce 10 day cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
+---
 version: 2
 updates:
-  - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: daily
+- package-ecosystem: bundler
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.0.4
+* Set dependency cooldowns for Dependabot
+
 # 1.0.3
 
 * Update dependencies

--- a/lib/siteimprove_api_client/version.rb
+++ b/lib/siteimprove_api_client/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 6.6.0
 =end
 
 module SiteimproveAPIClient
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end


### PR DESCRIPTION
## What

Adds 10 day dependency cooldowns for Dependabot and Renovate as appropriate
